### PR TITLE
change courseid to text

### DIFF
--- a/services/database.js
+++ b/services/database.js
@@ -21,7 +21,7 @@ function initialize() {
       
       CREATE TABLE IF NOT EXISTS "course" (
         id serial,
-        courseId integer,
+        courseId text,
         name text,
         credits integer,
         PRIMARY KEY (id)


### PR DESCRIPTION
'CourseId' is not the ID for the database, it should not be an int.
It is the name of the course identifier, such as 'CS-404',
"name" is the long name of the course, such as 'Advanced Web and Internet programming'.

I changed CourseId into 'text' instead of an 'int' in the database. If this is not correct, please inform me.