### PR TITLE
Feature edit course category

### DIFF
--- a/models/Course.test.js
+++ b/models/Course.test.js
@@ -31,7 +31,7 @@ function dataForGetCourse(rows, offset = 0) {
     const value = i + offset;
     data.push({
       id: `${value}`,
-      section: value ,
+      section: value,
       name: `Course-${value}`,
       credits: 3
     });
@@ -71,7 +71,7 @@ describe('Course Model', () => {
       const putDoc = {
         name: 'NewCourse',
         credits: 4,
-        courseId: 5
+        section: 5
       };
 
       db.query.mockResolvedValue({
@@ -79,7 +79,7 @@ describe('Course Model', () => {
       });
 
       await Course.editCourse(row.id, putDoc);
-      expect(db.query.mock.calls).toHaveLength(1);
+      expect(db.query.mock.calls).toHaveLength(2);
       expect(db.query.mock.calls[0]).toHaveLength(2);
       expect(db.query.mock.calls[0][0]).toBe(
         `UPDATE "course" SET name = $1, section = $2, credits = $3 WHERE id = $4 RETURNING *;`
@@ -113,17 +113,122 @@ describe('Course Model', () => {
       });
       await expect(Course.editCourse(row.id, putDoc)).rejects.toThrowError('Unexpected DB condition, update successful with no returned record');
     });
+
+    test('Edit a course to have new category prefix', async () => {
+      const data = dataForGetCourse(1);
+      const row = data[0];
+      row.name = "OldCourse"
+      row.credits = 4
+      const putDoc = {
+        name: 'NewCourse',
+        prefix: "CS"
+      };
+
+      db.query.mockResolvedValue({
+        rows: data
+      });
+
+      await Course.editCourse(row.id, putDoc);
+      expect(db.query.mock.calls).toHaveLength(4);
+      expect(db.query.mock.calls[0]).toHaveLength(1);
+      expect(db.query.mock.calls[0][0]).toBe(
+        `SELECT id FROM category WHERE prefix='CS';`
+      );
+      expect(db.query.mock.calls[1]).toHaveLength(2);
+      expect(db.query.mock.calls[1][0]).toBe(
+        `UPDATE "courseCategory" SET categoryid = $1 WHERE courseid = $2 RETURNING *;`
+      );
+      expect(db.query.mock.calls[2]).toHaveLength(2);
+      expect(db.query.mock.calls[2][0]).toBe(
+        `UPDATE "course" SET name = $1 WHERE id = $2 RETURNING *;`
+      );
+      expect(db.query.mock.calls[3]).toHaveLength(1);
+      expect(db.query.mock.calls[3][0]).toBe(
+        `SELECT course.id, course.name, course.credits, course.section, category.prefix FROM course INNER JOIN "courseCategory" ON "courseCategory".courseid = "course".id INNER JOIN "category" ON "category".id = "courseCategory".categoryid WHERE course.id = 1 LIMIT 1;`
+      );
+
+    });
+
+    test('Throw 400 for category prefix not found', async () => {
+      const data = dataForGetCourse(1);
+      const row = data[0];
+      const putDoc = {
+        name: 'NewCourse',
+        prefix: "cs"
+      };
+      db.query.mockResolvedValue({
+        rows: []
+      });
+      await expect(Course.editCourse(row.id, putDoc)).rejects.toThrowError('Invalid category prefix');
+    });
   });
+
+  test('Edit a courses category prefix only', async () => {
+    const data = dataForGetCourse(1);
+    const row = data[0];
+    const putDoc = {
+      prefix: "CS"
+    };
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    await Course.editCourse(row.id, putDoc);
+    expect(db.query.mock.calls).toHaveLength(3);
+    expect(db.query.mock.calls[0]).toHaveLength(1);
+    expect(db.query.mock.calls[0][0]).toBe(
+      `SELECT id FROM category WHERE prefix='CS';`
+    );
+    expect(db.query.mock.calls[1]).toHaveLength(2);
+    expect(db.query.mock.calls[1][0]).toBe(
+      `UPDATE "courseCategory" SET categoryid = $1 WHERE courseid = $2 RETURNING *;`
+    );
+    expect(db.query.mock.calls[2]).toHaveLength(1);
+    expect(db.query.mock.calls[2][0]).toBe(
+      `SELECT course.id, course.name, course.credits, course.section, category.prefix FROM course INNER JOIN "courseCategory" ON "courseCategory".courseid = "course".id INNER JOIN "category" ON "category".id = "courseCategory".categoryid WHERE course.id = 1 LIMIT 1;`
+
+    );
+  });
+
+  test('Throw 400 for no attributes provided', async () => {
+    const data = dataForGetCourse(1);
+    const row = data[0];
+    const putDoc = {};
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    await expect(Course.editCourse(row.id, putDoc)).rejects.toThrowError('Course attributes required');
+  });
+
+  test('Throw 500 for other DB error', async () => {
+    const data = dataForGetCourse(1);
+    const row = data[0];
+    const putDoc = {
+      prefix: "CS"
+    };
+    db.query.mockResolvedValueOnce({
+      rows: data
+    })
+    db.query.mockResolvedValueOnce({
+      rows: []
+    })
+
+    await expect(Course.editCourse(row.id, putDoc)).rejects.toThrowError('Unexpected DB condition');
+  });
+
 });
 
- describe('test deleteCourse', () => {
-      test('course delete', async () => {
-        const data = dataForDeleteCourse(1);
-        const row = data[0];
-        db.query.mockResolvedValue({ rows: data });
-        expect(await Course.deleteCourse(row.section)).toBe(`Successfully deleted course from db`);
-      });
-  
+
+
+describe('test deleteCourse', () => {
+  test('course delete', async () => {
+    const data = dataForDeleteCourse(1);
+    const row = data[0];
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    expect(await Course.deleteCourse(row.section)).toBe(`Successfully deleted course from db`);
+  });
+
   test('No parameters', async () => {
     db.query.mockResolvedValue({
       rows: []
@@ -142,96 +247,109 @@ describe('Course Model', () => {
 });
 
 describe('querying all courses', () => {
-  
-   beforeEach(() => {
+
+  beforeEach(() => {
     db.query.mockReset();
     db.query.mockResolvedValue(null);
   });
-  
-      test('should make a call to Course.findAll - no criteria, no limits, no offsets', async () => {
-        const data = dataForGetCourse(5);
-        db.query.mockResolvedValue({ rows: data });
-        const users = await Course.findAll();
-        expect(db.query.mock.calls).toHaveLength(1);
-        expect(db.query.mock.calls[0]).toHaveLength(2);
-        expect(db.query.mock.calls[0][0]).toBe('SELECT * from "course"  LIMIT $1 OFFSET $2;');
-        expect(db.query.mock.calls[0][1]).toHaveLength(2);
-        expect(db.query.mock.calls[0][1][0]).toBe(100);
-        expect(db.query.mock.calls[0][1][1]).toBe(0);
-        expect(users).toHaveLength(data.length);
-        for (let i = 0; i < data.length; i++) {
-          for (const key in Object.keys(data[i])) {
-            expect(users[i]).toHaveProperty(key, data[i][key]);
-          }
-        }
-      });
-  
-      test('should make a call to Course.findAll - with criteria, no limits, no offsets', async () => {
-        const data = dataForGetCourse(5);
-        db.query.mockResolvedValue({ rows: data });
-        const users = await Course.findAll({ credits: 3}, undefined);
-        expect(db.query.mock.calls).toHaveLength(1);
-        expect(db.query.mock.calls[0]).toHaveLength(2);
-        expect(db.query.mock.calls[0][0]).toBe(
-          'SELECT * from "course" WHERE "credits"=$1 LIMIT $2 OFFSET $3;'
-        );
-        expect(db.query.mock.calls[0][1]).toHaveLength(3);
-        expect(db.query.mock.calls[0][1][0]).toBe(3);
-        expect(db.query.mock.calls[0][1][1]).toBe(100);
-        expect(db.query.mock.calls[0][1][2]).toBe(0);
-        expect(users).toHaveLength(data.length);
-        for (let i = 0; i < data.length; i++) {
-          for (const key in Object.keys(data[i])) {
-            expect(users[i]).toHaveProperty(key, data[i][key]);
-          }
-        }
-      });
-  
-      test('should make a call to Course.findAll - with criteria, with limits, no offsets', async () => {
-        const data = dataForGetCourse(3);
-        db.query.mockResolvedValue({ rows: data });
-        const courses = await Course.findAll({credits: 3}, 3);
-        expect(db.query.mock.calls).toHaveLength(1);
-        expect(db.query.mock.calls[0]).toHaveLength(2);
-        expect(db.query.mock.calls[0][0]).toBe(
-          'SELECT * from "course" WHERE "credits"=$1 LIMIT $2 OFFSET $3;'
-        );
-        expect(db.query.mock.calls[0][1]).toHaveLength(3);
-        expect(db.query.mock.calls[0][1][0]).toBe(3);
-        expect(db.query.mock.calls[0][1][1]).toBe(3);
-        expect(db.query.mock.calls[0][1][2]).toBe(0);
-        expect(courses).toHaveLength(data.length);
-        for (let i = 0; i < data.length; i++) {
-          for (const key in Object.keys(data[i])) {
-            expect(courses[i]).toHaveProperty(key, data[i][key]);
-          }
-        }
-      });
-  
-      test('should make a call to Course.findAll - with criteria, with limits, with offsets', async () => {
-        const data = dataForGetCourse(3, 1);
-        db.query.mockResolvedValue({ rows: data });
-        const courses = await Course.findAll({credits: 3 }, 3, 1);
-        expect(db.query.mock.calls).toHaveLength(1);
-        expect(db.query.mock.calls[0]).toHaveLength(2);
-        expect(db.query.mock.calls[0][0]).toBe(
-          'SELECT * from "course" WHERE "credits"=$1 LIMIT $2 OFFSET $3;'
-        );
-        expect(db.query.mock.calls[0][1]).toHaveLength(3);
-        expect(db.query.mock.calls[0][1][0]).toBe(3);
-        expect(db.query.mock.calls[0][1][1]).toBe(3);
-        expect(db.query.mock.calls[0][1][2]).toBe(1);
-        expect(courses).toHaveLength(data.length);
-        for (let i = 0; i < data.length; i++) {
-          for (const key in Object.keys(data[i])) {
-            expect(courses[i]).toHaveProperty(key, data[i][key]);
-          }
-        }
-      });
-  
-      test('should return null for database error', async () => {
-        db.query.mockRejectedValueOnce(new Error('a testing database error'));
-        await expect(Course.findAll()).rejects.toThrowError('a testing database error');
-      });
- });
 
+  test('should make a call to Course.findAll - no criteria, no limits, no offsets', async () => {
+    const data = dataForGetCourse(5);
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    const users = await Course.findAll();
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(2);
+    expect(db.query.mock.calls[0][0]).toBe('SELECT * from "course"  LIMIT $1 OFFSET $2;');
+    expect(db.query.mock.calls[0][1]).toHaveLength(2);
+    expect(db.query.mock.calls[0][1][0]).toBe(100);
+    expect(db.query.mock.calls[0][1][1]).toBe(0);
+    expect(users).toHaveLength(data.length);
+    for (let i = 0; i < data.length; i++) {
+      for (const key in Object.keys(data[i])) {
+        expect(users[i]).toHaveProperty(key, data[i][key]);
+      }
+    }
+  });
+
+  test('should make a call to Course.findAll - with criteria, no limits, no offsets', async () => {
+    const data = dataForGetCourse(5);
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    const users = await Course.findAll({
+      credits: 3
+    }, undefined);
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(2);
+    expect(db.query.mock.calls[0][0]).toBe(
+      'SELECT * from "course" WHERE "credits"=$1 LIMIT $2 OFFSET $3;'
+    );
+    expect(db.query.mock.calls[0][1]).toHaveLength(3);
+    expect(db.query.mock.calls[0][1][0]).toBe(3);
+    expect(db.query.mock.calls[0][1][1]).toBe(100);
+    expect(db.query.mock.calls[0][1][2]).toBe(0);
+    expect(users).toHaveLength(data.length);
+    for (let i = 0; i < data.length; i++) {
+      for (const key in Object.keys(data[i])) {
+        expect(users[i]).toHaveProperty(key, data[i][key]);
+      }
+    }
+  });
+
+  test('should make a call to Course.findAll - with criteria, with limits, no offsets', async () => {
+    const data = dataForGetCourse(3);
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    const courses = await Course.findAll({
+      credits: 3
+    }, 3);
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(2);
+    expect(db.query.mock.calls[0][0]).toBe(
+      'SELECT * from "course" WHERE "credits"=$1 LIMIT $2 OFFSET $3;'
+    );
+    expect(db.query.mock.calls[0][1]).toHaveLength(3);
+    expect(db.query.mock.calls[0][1][0]).toBe(3);
+    expect(db.query.mock.calls[0][1][1]).toBe(3);
+    expect(db.query.mock.calls[0][1][2]).toBe(0);
+    expect(courses).toHaveLength(data.length);
+    for (let i = 0; i < data.length; i++) {
+      for (const key in Object.keys(data[i])) {
+        expect(courses[i]).toHaveProperty(key, data[i][key]);
+      }
+    }
+  });
+
+  test('should make a call to Course.findAll - with criteria, with limits, with offsets', async () => {
+    const data = dataForGetCourse(3, 1);
+    db.query.mockResolvedValue({
+      rows: data
+    });
+    const courses = await Course.findAll({
+      credits: 3
+    }, 3, 1);
+    expect(db.query.mock.calls).toHaveLength(1);
+    expect(db.query.mock.calls[0]).toHaveLength(2);
+    expect(db.query.mock.calls[0][0]).toBe(
+      'SELECT * from "course" WHERE "credits"=$1 LIMIT $2 OFFSET $3;'
+    );
+    expect(db.query.mock.calls[0][1]).toHaveLength(3);
+    expect(db.query.mock.calls[0][1][0]).toBe(3);
+    expect(db.query.mock.calls[0][1][1]).toBe(3);
+    expect(db.query.mock.calls[0][1][2]).toBe(1);
+    expect(courses).toHaveLength(data.length);
+    for (let i = 0; i < data.length; i++) {
+      for (const key in Object.keys(data[i])) {
+        expect(courses[i]).toHaveProperty(key, data[i][key]);
+      }
+    }
+  });
+
+  test('should return null for database error', async () => {
+    db.query.mockRejectedValueOnce(new Error('a testing database error'));
+    await expect(Course.findAll()).rejects.toThrowError('a testing database error');
+  });
+});

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -36,6 +36,7 @@ module.exports = () => {
   // PUT body should contain JSON for course name, section, credits
   router.put('/:id', authorizeSession, async (req, res, next) => {
     try {
+
       // Get the course to edit and make sure it exists in database
       const id = req.params.id;
       const course = await Course.findOne({
@@ -58,8 +59,25 @@ module.exports = () => {
           const newCourseJSON = {
             name: req.body.name,
             section: req.body.section,
-            credits: req.body.credits
+            credits: req.body.credits,
+            prefix: req.body.prefix
           };
+
+          // Prevent attributes from becoming 'null' if not entered to edit
+          // const newCourseJSON = {};
+          // if (!(req.body.name === null))
+          //   newCourseJSON.name = req.body.name
+
+          // if (!(req.body.section === null))
+          //   newCourseJSON.section = req.body.section
+
+          // if (!(req.body.credits === null))
+          //   newCourseJSON.credits = req.body.credits
+
+          // if (!(req.body.prefix === null))
+          //   newCourseJSON.prefix = req.body.prefix
+
+
 
           // Call the function to edit the course parameters and return results
           const updatedCourse = await Course.editCourse(id, newCourseJSON);
@@ -81,11 +99,11 @@ module.exports = () => {
     try {
       const criteria = {};
 
-      if(req.query.credits) {
+      if (req.query.credits) {
         criteria.credits = req.query.credits;
       }
 
-      const courses = await Course.findAll(criteria,req.query.limit,req.query.offset);
+      const courses = await Course.findAll(criteria, req.query.limit, req.query.offset);
       return res.send(courses)
     } catch (error) {
       next(error);
@@ -95,35 +113,41 @@ module.exports = () => {
   router.get('/:courseid', authorizeSession, async (req, res, next) => {
     try {
       const courseid = req.params.courseid;
-      const courses = await Course.findAll({id: courseid});
-      if(isEmpty(courses)) {
+      const courses = await Course.findAll({
+        id: courseid
+      });
+      if (isEmpty(courses)) {
         throw new HttpError.NotFound();
       }
       log.info(`${req.method} ${req.originalUrl} success: returning courses ${courseid}`);
       return res.send(courses);
 
-    } catch(error) {
+    } catch (error) {
       next(error);
     }
   })
-  
+
   router.delete('/', authorizeSession, async (req, res, next) => {
     try {
       const Id = req.body.id;
       if (isEmpty(req.body) || !Id) {
         throw new HttpError.BadRequest('Required parameters are missing');
       }
-      if(res.locals.userId == null) {
-        throw new HttpError.Forbidden('You are not allowed to do this'); 
-      }
-      const sender = await User.findOne({ userId: res.locals.userId });
-      if(!sender || isEmpty(sender)) {
-        throw new HttpError.Forbidden('You are not allowed to do this'); 
-      }
-      if(!(sender.role === 'director')) {
+      if (res.locals.userId == null) {
         throw new HttpError.Forbidden('You are not allowed to do this');
       }
-      const course = await Course.findOne({ id: Id });
+      const sender = await User.findOne({
+        userId: res.locals.userId
+      });
+      if (!sender || isEmpty(sender)) {
+        throw new HttpError.Forbidden('You are not allowed to do this');
+      }
+      if (!(sender.role === 'director')) {
+        throw new HttpError.Forbidden('You are not allowed to do this');
+      }
+      const course = await Course.findOne({
+        id: Id
+      });
       if (isEmpty(course)) {
         throw new HttpError.NotFound();
       }

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -63,7 +63,7 @@ module.exports = () => {
         throw new HttpError.NotFound();
       } else {
         // Check the user's role for permission (must be role 'director')
-        if (sender.role === 'director') {
+        if (sender.role === 'director' || sender.role === 'admin') {
           const newCourseJSON = {
             name: req.body.name,
             section: req.body.section,

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -63,22 +63,6 @@ module.exports = () => {
             prefix: req.body.prefix
           };
 
-          // Prevent attributes from becoming 'null' if not entered to edit
-          // const newCourseJSON = {};
-          // if (!(req.body.name === null))
-          //   newCourseJSON.name = req.body.name
-
-          // if (!(req.body.section === null))
-          //   newCourseJSON.section = req.body.section
-
-          // if (!(req.body.credits === null))
-          //   newCourseJSON.credits = req.body.credits
-
-          // if (!(req.body.prefix === null))
-          //   newCourseJSON.prefix = req.body.prefix
-
-
-
           // Call the function to edit the course parameters and return results
           const updatedCourse = await Course.editCourse(id, newCourseJSON);
           res.status(200);

--- a/services/initDatabase.sql
+++ b/services/initDatabase.sql
@@ -27,6 +27,14 @@ CREATE TABLE IF NOT EXISTS "semester" (
 );
 CREATE INDEX IF NOT EXISTS "IDX_semester_id" ON "semester" ("id");
 
+CREATE TABLE IF NOT EXISTS "category" (
+	id serial,
+	name text,
+	prefix text,
+	PRIMARY KEY (id)
+);
+CREATE INDEX IF NOT EXISTS "IDX_category_id" ON "category" ("id");
+
 -- Relations
 CREATE TABLE IF NOT EXISTS "userCourse" (
 	userId integer REFERENCES "user"(id),
@@ -37,6 +45,32 @@ CREATE TABLE IF NOT EXISTS "userCourse" (
 );
 CREATE INDEX IF NOT EXISTS "IDX_user_course_semester_id" ON "userCourse" (userId, courseId, semesterId);
 
+CREATE TABLE IF NOT EXISTS "courseSemester" (
+	semesterId integer,
+	courseId integer,
+	PRIMARY KEY (semesterId, courseId),
+	FOREIGN KEY (semesterId)
+		REFERENCES "semester" (id),
+	FOREIGN KEY (courseId)
+		REFERENCES "course" (id)
+);
+
+
+CREATE TABLE IF NOT EXISTS "courseCategory" (
+	courseId integer,
+	categoryId integer,
+	PRIMARY KEY (courseId, categoryId),
+	FOREIGN KEY (courseId)
+		REFERENCES "course" (id),
+	FOREIGN KEY (categoryId)
+		REFERENCES "category" (id)
+);
+
+-- Changing fields
+ALTER TABLE "course" DROP COLUMN IF EXISTS "courseId";
+ALTER TABLE "course" ADD COLUMN IF NOT EXISTS "section" text;
+ALTER TABLE "semester" ADD COLUMN IF NOT EXISTS "year" integer;
+ALTER TABLE "semester" DROP COLUMN IF EXISTS "name";
 -- Run to quickly remove all tables for testing.
 -- DROP TABLE IF EXISTS "semester" cascade;
 -- DROP TABLE IF EXISTS "course" cascade;


### PR DESCRIPTION
Acts the same as editing a course attribute (name, section, etc.), but now with a category prefix as well ("prefix": "CS"). 
Takes a course ID in the PUT request and a prefix as an attribute, and changes the categoryID for that course in courseCategory to match the id of the newly entered prefix. Responds with course details if successful or errors if prefix is not found in database. 
Includes Jest/Mocking to account for new prefixes, queries, and possible errors.
Might still go back to clean up some attribute validation and long queries.